### PR TITLE
SakuraScriptのエスケープ処理を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,14 @@ httpsじゃないWebサイトだと制限かかって動かないけどそれは
 ## 下記、イベント実装例(開発者向け)
 
 ### 里々
-```
-＊OnUWBShowPageInfo
-：（R0）を見ているんですね。URLは（R1）ですか。
-```
+里々では`Security Level: external`のもとでSakurScriptタグをエスケープする方法が無いため、非推奨。
 
 ### YAYA
 ```C
 OnUWBShowPageInfo
 {
-  _pageTitle = reference[0]
-  _pageURL = reference[1]
+  _pageTitle = SHIORI3FW.EscapeAllTags(reference[0])
+  _pageURL = SHIORI3FW.EscapeAllTags(reference[1])
 
   "「%(_pageTitle)」を見ているんですね。URLは「%(_pageURL)」ですか。\e"
 }
@@ -51,6 +48,7 @@ ExternalEvent.OnUWBShowPageInfo
     OnUWBShowPageInfo()
 }
 ```
-"ExternalEvent.OnUWBShowPageInfo"はSSTPがSecurity Level: externalで通知されるため、それを明示的に受け付けるための記載。
+`SHIORI3FW.EscapeAllTags`はYAYAのシステム辞書optional.dicにある全てのSakurScriptタグをエスケープ（\付加）する関数。  
+`ExternalEvent.OnUWBShowPageInfo`はSSTPが`Security Level: external`で通知されるため、それを明示的に受け付けるための記載。
 
 基本的にはExternal...だけでもこの拡張機能は動作しますが、古いシステム辞書を使っている場合は"OnUWBShowPageInfo"での定義が必要です。


### PR DESCRIPTION
`Security Level: external`の場合に最も留意すべきは送信元が不特定多数であることで、  
`Reference0`や`Reference1`に危険なSakuraScriptを仕込むことで攻撃が可能となってしまいます。  
特に最近はWebページを開くだけでSSTP over HTTPを飛ばすことが可能なので危険度は増しています。

YAYAの場合はシステム辞書に以下の関数が定義されています。

```
//------------------------------------------------------------------------------
//　関数名：SHIORI3FW.EscapeAllTags
//　機能　：全てのさくらスクリプトタグをエスケープ（\付加）する。
//　引数　：argv0＝テキスト
//------------------------------------------------------------------------------
SHIORI3FW.EscapeAllTags{
	_txt=_argv[0]
	_txt=REPLACE(_txt,'\\',ESCAPE_TAG_1)
	_txt=REPLACE(_txt,'\%',ESCAPE_TAG_2)
	_txt=REPLACE(_txt,'\','\\')
	_txt=REPLACE(_txt,'%','\%')
	_txt=REPLACE(_txt,ESCAPE_TAG_2,'\%')
	_txt=REPLACE(_txt,ESCAPE_TAG_1,'\\')
	_txt
}
```

これを使ってSakuraScriptをエスケープすべきです。

なお、里々は`Security Level: external`のもとではすべての内部関数処理が封じられているのでエスケープはできません。  
よって使用そのものを禁止すべきと考えます。

This is my personal opinion at this time and we may have another better ideas.   
Feel free to kick this PR.